### PR TITLE
Explicitly load modules from current directory

### DIFF
--- a/find_bad_redactions.pl
+++ b/find_bad_redactions.pl
@@ -19,7 +19,7 @@ if(@ARGV != 1)
 
 $filename = $ARGV[0];
 
-require "lib/parse_pdf_for_redactions.pl";
+require "./lib/parse_pdf_for_redactions.pl";
 
 open(F, $filename);
 

--- a/find_bad_redactions_in_files.pl
+++ b/find_bad_redactions_in_files.pl
@@ -24,7 +24,7 @@ if(@ARGV != 2)
 $filename = $ARGV[0];
 $results = $ARGV[1];
 
-require "lib/parse_pdf_for_redactions.pl";
+require "./lib/parse_pdf_for_redactions.pl";
 
 open(F, $filename);
 

--- a/lib/parse_pdf_for_redactions.pl
+++ b/lib/parse_pdf_for_redactions.pl
@@ -16,15 +16,15 @@ use 5.006;
 use warnings;
 use strict;
 use Data::Dumper;
-require "lib/pdf_state.pm";
-require "lib/pdf_object.pm";
-require "lib/extract_text_objects.pl";
+require "./lib/pdf_state.pm";
+require "./lib/pdf_object.pm";
+require "./lib/extract_text_objects.pl";
 
 use List::Util qw[min max];
 use CAM::PDF;
 use CAM::PDF::Content;
 
-require "lib/find_xxed_files.pl";
+require "./lib/find_xxed_files.pl";
 
 # Pretty printing for debugging.
 

--- a/lib/pdf_state.pm
+++ b/lib/pdf_state.pm
@@ -14,7 +14,7 @@ use Dumpvalue;
 
 use List::Util qw[min max];
 
-require "lib/pdf_matrix.pm";
+require "./lib/pdf_matrix.pm";
 
 # IIRC, a significant amount of the code in this library is redundant, because CAM::PDF does more than
 # I originally realized. So it's a good idea to use new_from_node to get information about text objects,


### PR DESCRIPTION
Perl 5.26 removed "." from @INC due to security concerns when scripts
are run from untrusted directories. This commit adds a leading "./" to
require paths to fix module resolution in newer versions of Perl.